### PR TITLE
fix: assignment state return uppercase

### DIFF
--- a/src/pages/manage-assignment/components/detail-assignment/index.tsx
+++ b/src/pages/manage-assignment/components/detail-assignment/index.tsx
@@ -1,6 +1,7 @@
 import FormModal from "../../../../components/ui/form-modal"
 import FormModalGroup from "../../../../components/ui/form-modal-group"
 import { AssignmentDetail } from "../../../../types/assignment"
+import { getStatusLabel } from "../../../../utils/status-label"
 
 interface DetailedAssignmentProps {
     closeModal: () => void
@@ -23,7 +24,7 @@ const DetailAssignmentModal = (props: DetailedAssignmentProps) => {
             <FormModalGroup title="Assigned To" value={assignedTo}/>
             <FormModalGroup title="Assigned By" value={assignedBy}/>
             <FormModalGroup title="Assigned Date" value={assignedDate}/>
-            <FormModalGroup title="State" value={status}/>
+            <FormModalGroup title="State" value={getStatusLabel(status)}/>
             <FormModalGroup title="Note" value={note}/>
         </FormModal>
     )

--- a/src/pages/manage-assignment/index.tsx
+++ b/src/pages/manage-assignment/index.tsx
@@ -12,6 +12,7 @@ import { Assignment, AssignmentDetail } from "../../types/assignment";
 import DetailAssignmentModal from "./components/detail-assignment";
 import DeleteAssignmentModal from "./components/delete-assignment";
 import { useDebounce } from "../../hooks/useDebounce";
+import { getStatusLabel } from "../../utils/status-label";
 
 const getColumns = (props: {
   handlers: {
@@ -32,7 +33,13 @@ const getColumns = (props: {
     { key: "assignedTo", title: "Assigned to" },
     { key: "assignedBy", title: "Assigned By" },
     { key: "assignedDate", title: "Assigned Date" },
-    { key: "status", title: "State" },
+    {
+      key: "status",
+      title: "State",
+      render: (value) => {
+        return <span>{getStatusLabel(String(value))}</span>
+      }
+    },
     {
       key: "action",
       actions: [

--- a/src/utils/status-label.ts
+++ b/src/utils/status-label.ts
@@ -1,0 +1,12 @@
+export const getStatusLabel = (status: string): string => {
+    switch (status) {
+        case "WAITING":
+            return "Waiting for Acceptance";
+        case "ACCEPTED":
+            return "Accepted";
+        case "DECLINED":
+            return "Declined";
+        default:
+            return status;
+    }
+};


### PR DESCRIPTION
**Purpose:**
- Add function getStatusLabel to handle status uppercase response from back-end to lowercase.
- This function applies to View Assignment List and View Detail Assignment
File:
status-label.ts (new)